### PR TITLE
:hammer: Give the unit tests TestCase a namespace

### DIFF
--- a/tests/Asserts/ArtisanAssertsTest.php
+++ b/tests/Asserts/ArtisanAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class ArtisanAssertsTest extends TestCase
 {
     /** @test */

--- a/tests/Asserts/CollectionAssertsTest.php
+++ b/tests/Asserts/CollectionAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class CollectionAssertsTest extends TestCase
 {
     /** @test */

--- a/tests/Asserts/DatabaseAssertsTest.php
+++ b/tests/Asserts/DatabaseAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class DatabaseAssertsTest extends TestCase
 {
     public function setUp()

--- a/tests/Asserts/EloquentAssertsTest.php
+++ b/tests/Asserts/EloquentAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class EloquentAssertsTest extends TestCase
 {
     /** @test */

--- a/tests/Asserts/ExceptionAssertsTest.php
+++ b/tests/Asserts/ExceptionAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class ExceptionAssertsTest extends TestCase
 {
     /** @test */

--- a/tests/Asserts/FilesystemAssertsTest.php
+++ b/tests/Asserts/FilesystemAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class FilesystemAssertsTest extends TestCase
 {
     /** @test */

--- a/tests/Asserts/LogFileAssertsTest.php
+++ b/tests/Asserts/LogFileAssertsTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
+use Illuminated\Testing\Tests\TestCase;
 
 class LogFileAssertsTest extends TestCase
 {

--- a/tests/Asserts/ReflectionAssertsTest.php
+++ b/tests/Asserts/ReflectionAssertsTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
+use Illuminated\Testing\Tests\TestCase;
 
 class ReflectionAssertsTest extends TestCase
 {

--- a/tests/Asserts/ScheduleAssertsTest.php
+++ b/tests/Asserts/ScheduleAssertsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminated\Testing\Tests\TestCase;
 
 class ScheduleAssertsTest extends TestCase
 {

--- a/tests/Asserts/ServiceProviderAssertsTest.php
+++ b/tests/Asserts/ServiceProviderAssertsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class ServiceProviderAssertsTest extends TestCase
 {
     protected function getPackageProviders($app)

--- a/tests/Helpers/ApplicationHelpersTest.php
+++ b/tests/Helpers/ApplicationHelpersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class ApplicationHelpersTest extends TestCase
 {
     /** @test */

--- a/tests/Helpers/ArtisanHelpersTest.php
+++ b/tests/Helpers/ArtisanHelpersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminated\Testing\Tests\TestCase;
+
 class ArtisanHelpersTest extends TestCase
 {
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace Illuminated\Testing\Tests;
+
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Illuminated\Testing\TestingTools;
+use Kernel;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {

--- a/tests/TestingToolsTest.php
+++ b/tests/TestingToolsTest.php
@@ -13,6 +13,7 @@ use Illuminated\Testing\Asserts\ServiceProviderAsserts;
 use Illuminated\Testing\Helpers\ApplicationHelpers;
 use Illuminated\Testing\Helpers\ArtisanHelpers;
 use Illuminated\Testing\TestingTools;
+use Illuminated\Testing\Tests\TestCase;
 
 class TestingToolsTest extends TestCase
 {


### PR DESCRIPTION
Give the unit tests TestCase a namespace, so it won't conflict with Laravel's TestCase.

By default in Laravel applications, the \TestCase class is provided as base test case for all unit tests.
The base `\TestCase` class in this libraries' unit test suite shows confliction errors in phpstorm, because the same class exists twice in the project.

By giving the base test case of this project a namespace, the conflict is resolved.